### PR TITLE
Update theme.json for "Smaller Quick Access Tabs"

### DIFF
--- a/Smaller Quick Access Tabs/theme.json
+++ b/Smaller Quick Access Tabs/theme.json
@@ -6,6 +6,34 @@
     "target": "Tweak",
     "description": "Reduces the height of quick access tabs to save some space and overcome glitches.",
     "inject": {
-        "shared.css": ["QuickAccess"]
+        "shared.css": [
+            "QuickAccess"
+        ]
+    },
+    "patches": {
+        "Tab Size": {
+            "default": "Full",
+            "type": "slider",
+            "values": {
+                "Square": {
+                    "--qamTab-size": [
+                        "48px",
+                        "QuickAccess"
+                    ]
+                },
+                "Compact": {
+                    "--qamTab-size": [
+                        "52px",
+                        "QuickAccess"
+                    ]
+                },
+                "Full": {
+                    "--qamTab-size": [
+                        "56px",
+                        "QuickAccess"
+                    ]
+                }
+            }
+        }
     }
 }

--- a/Smaller Quick Access Tabs/theme.json
+++ b/Smaller Quick Access Tabs/theme.json
@@ -2,7 +2,7 @@
     "name": "Smaller Quick Access Tabs",
     "version": "v1.0",
     "author": "RasitAyaz",
-    "manifest_version": 3,
+    "manifest_version": 5,
     "target": "Tweak",
     "description": "Reduces the height of quick access tabs to save some space and overcome glitches.",
     "inject": {


### PR DESCRIPTION
Hi there!

This is my first Pull Request on GitHub. Please let me know if I've done anything wrong!

I've added additional patches to select between three tab size options:
Full - the max tab size before breaking the Quick Access Menu while in-game
Compact - a slightly smaller height
Square - the current default

I made Full the new default, but feel free to keep it Square.

This update needs another change I made to shared.css to work properly. I'll do a Pull Request for that now too.

Thanks!