### PR TITLE
Option to hide verified & playable icons

### DIFF
--- a/Better Game Badges/compatibility/hideplayable.css
+++ b/Better Game Badges/compatibility/hideplayable.css
@@ -1,0 +1,15 @@
+.shared_svg_library_SteamDeckCompatInfo_2LcFI {
+  background: none !important;
+}
+ 
+.shared_svg_library_SteamDeckCompatInfo_2LcFI > svg.shared_svg_library_SteamDeckCompatVerified_3mvZq,
+.shared_svg_library_SteamDeckCompatInfo_2LcFI > svg.shared_svg_library_SteamDeckCompatPlayable_S7BDm {
+  display: none;
+}
+ 
+.shared_svg_library_SteamDeckCompatInfo_2LcFI > svg.shared_svg_library_SteamDeckCompatIcon_2hEWY,
+.shared_svg_library_SteamDeckCompatInfo_2LcFI > svg.shared_svg_library_SteamDeckCompatLogo_Tplfb {
+  background-color: #0e141b;
+  padding: 2px;
+  border-radius: 20px;
+}

--- a/Better Game Badges/theme.json
+++ b/Better Game Badges/theme.json
@@ -31,7 +31,11 @@
         "Without the Deck icon": {
           "compatibility/no_deck_icon.css": ["SP"]
         },
-        "With the Deck icon": {}
+        "With the Deck icon": {},
+        "Hide Verified & Playable & Deck icon": {
+          "compatibility/no_deck_icon.css": ["SP"],
+          "compatibility/hideplayable.css": ["SP"]
+        }
       }
     },
     "All achieved badges": {


### PR DESCRIPTION
For https://github.com/rasitayaz/steam-deck-themes/issues/5

I removed shared background for deck icon and verification icon, so there won't be a black dot left when the verification is hidden. Then I draw the same background under the verification icon, so those are shown still have a background. Doing this would make the background of deck icon and verification icon separated, which doesn't look good, so I make it only work with hide deck icon.